### PR TITLE
Remove `title` & `url` from xApp share command options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -282,13 +282,9 @@ class xAppThread extends EventEmitter {
   }
 
   share(shareOptions: xAppActionShare): Promise<boolean | Error> {
-    if (
-      typeof shareOptions?.url !== "string" &&
-      typeof shareOptions?.title !== "string" &&
-      typeof shareOptions?.text !== "string"
-    ) {
+    if (typeof shareOptions?.text !== "string") {
       return Promise.reject(
-        new Error("xApp.share: Invalid argument: `title` / `text` / `url`")
+        new Error("xApp.share: Invalid argument: `text`")
       );
     }
     return xAppActionAttempt("share", shareOptions);

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,9 +76,7 @@ export interface xAppActionOpenBrowser extends AnyJson {
 
 export interface xAppActionShare {
   // command: share
-  title?: string;
   text?: string;
-  url?: string;
 }
 
 export interface xAppActionClose {


### PR DESCRIPTION
`title` is only available on android and is not showing in all android versions, `url` is only for iOS.

this is confusing for devs, so lets only keep `text` as they can share url and text with this param.